### PR TITLE
deployment: Put `/usr/local/bin:/usr/bin` at front of `PATH`

### DIFF
--- a/src/deployment/DeploymentInstance-Cfn.yaml
+++ b/src/deployment/DeploymentInstance-Cfn.yaml
@@ -151,6 +151,7 @@ Resources:
                         echo \"---\"; \
                         echo \"Initiating nodejs and serverless installs\"; \
                         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash; \
+                        export PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin; \
                         . ~/.nvm/nvm.sh; \
                         source ~/.bashrc; \
                         nvm install v14.17.0; \


### PR DESCRIPTION
This is needed so that `/usr/bin/packer` for building AMIs has precedence over `/usr/sbin/packer` when `PATH` is echoed into `.bash_profile` later on in this setup script.

https://github.com/cracklib/cracklib/issues/7

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
