### PR TITLE
Add `cloudformation:GetTemplate` to deployment VM

### DIFF
--- a/src/deployment/DeploymentInstance-Cfn.yaml
+++ b/src/deployment/DeploymentInstance-Cfn.yaml
@@ -272,6 +272,7 @@ Resources:
                   - cloudformation:DeleteStack
                   - cloudformation:UpdateTerminationProtection
                   - cloudformation:ListStackResources
+                  - cloudformation:GetTemplate
                   - cloudformation:ValidateTemplate
                   - cloudformation:DescribeStackEvents
                 Effect: Allow


### PR DESCRIPTION
# Description
This is needed so the deployment VM can query the existing CDK2 bootstrap stack

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
