### PR TITLE
Use example.yml as base for config

### DIFF
--- a/doc/deployment/Step2-DeployServiceWorkbench.md
+++ b/doc/deployment/Step2-DeployServiceWorkbench.md
@@ -31,7 +31,7 @@ tar -xzf v5.1.1.tar.gz
 
 ```bash
 cd /home/ec2-user/tmp/service-workbench-on-aws-5.1.1/main/config/settings
-cp .defaults.yml treprod.yml
+cp example.yml treprod.yml
 nano treprod.yml
 ```
 


### PR DESCRIPTION
# Description
`.defaults.yml` contains all default values. By using `example.yml` instead we only need to change/uncomment the required settings, which makes it easier to see how the TRE has been customised since the defaults are omitted.

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
