### PR TITLE
Add intro/background info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ first, either by
 [opening a GitHub issue on this repository](https://github.com/HicResearch/TREEHOOSE/issues)
 or by emailing `hicsupport@dundee.ac.uk`.
 
-We can talk you through some of the current strengths and weaknesses of the
-platform, and include your requirements when planning future work.
+We can help demonstrate features of the platform and see how they match your requirements,
+and discuss future enhancements.
 
 ---
 


### PR DESCRIPTION
Adds a bit more introduction and background to the README.

Suggests that people contact us before deploying.

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
